### PR TITLE
Fix to checks for empty values

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,5 @@ Common configuration issues or error messages are logged to the project logs.  A
 This module uses some core REDCap methods not documented for EM usage.  As a result, there is a higher chance future updates to REDCap could affect this project.  Use of this module should be tested before/after each upgrade.
 
 ### Fixes
+2021-12-13 Fix to empty value checking so '0' (e.g. as stratum or allocation value) is treated as not empty.
 2021-04-26 Fixed a bug where smart-variables using the instrument name were failing

--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ Common configuration issues or error messages are logged to the project logs.  A
 This module uses some core REDCap methods not documented for EM usage.  As a result, there is a higher chance future updates to REDCap could affect this project.  Use of this module should be tested before/after each upgrade.
 
 ### Fixes
-2021-12-13 Fix to empty value checking so '0' (e.g. as stratum or allocation value) is treated as not empty.
+2021-12-13 Fix to empty value checking so '0' (e.g. as stratum or allocation value) is treated as not empty.  
 2021-04-26 Fixed a bug where smart-variables using the instrument name were failing

--- a/RealtimeRandomization.php
+++ b/RealtimeRandomization.php
@@ -57,7 +57,7 @@ class RealtimeRandomization extends \ExternalModules\AbstractExternalModule {
 
         // Are they already randomized
         list($randField, $randValue) = Randomization::getRandomizedValue($record);
-        if (!empty($randValue)) {
+        if ($randValue != '') {
             $this->emDebug($record . " already randomized: " . $randValue);
             return;
         };
@@ -73,7 +73,7 @@ class RealtimeRandomization extends \ExternalModules\AbstractExternalModule {
         $fields = array();
         foreach ($randAttr['strata'] as $field_name => $event_id) {
             $q = REDCap::getData($project_id,'array',$record, $field_name, $event_id);
-            if (empty($q[$record][$event_id][$field_name])) {
+            if ($q[$record][$event_id][$field_name] == '') {
                 $this->emDebug("Missing required strata value for $field_name");
                 return;
             } else {

--- a/RealtimeRandomization.php
+++ b/RealtimeRandomization.php
@@ -80,7 +80,8 @@ class RealtimeRandomization extends \ExternalModules\AbstractExternalModule {
                 $fields[$field_name] = $q[$record][$event_id][$field_name];
             }
         }
-
+        $group_id = ($randAttr['group_by'] === null) ? null : $group_id; // only pass group id when DAG is a stratification factor
+		
         // Randomize and return aid key
         $aid = Randomization::randomizeRecord($record, $fields, $group_id);
 


### PR DESCRIPTION
Fix to empty value checking so '0' (e.g. as stratum or allocation value) is treated as not empty. `empty('0')` returns `true` so use `'0' == ''` instead.